### PR TITLE
Enhance FSM defaults, experimental constant node elimination

### DIFF
--- a/CFGs.yml
+++ b/CFGs.yml
@@ -1,0 +1,16 @@
+replace:
+  val:
+    - - m: "{[^}]*}"
+        r: ""
+
+Dyck:
+  - val: "{Dyck:.8 1 1.2}{Dyck:.8 1 1.2}"
+  - val: "[{Dyck:1 .8 1.1}]"
+  - val: ""
+    freq: d.1
+
+binPalindrome:
+  - val: ""
+    freq: d.1
+  - val: "1{binPalindrome}1"
+  - val: "0{binPalindrome}0"

--- a/recursive.yml
+++ b/recursive.yml
@@ -1,3 +1,11 @@
+channels:
+  p: "Pathsim"
+
+replace:
+  val:
+    - S:
+        default: ["{}{}"]
+# Simple infinite recursion
 A:
   - val: "{A} {A}"
 
@@ -44,11 +52,39 @@ y:
   - val: e
     ipa: e
 
+# "Wide" expansion demonstration (limited to depth**2 expansions)
 W:
   - val: "{W}{W}{W}{W}{W}{W}{W}{W}{W}{W}{W}{W}{W}{W}{W}{W}"
-    freq: 1
 
+# This node produces its own path
+P:
+  - val: "+0"
+    p: "+0"
+    freq: d.1
+  - val: "+1{R:.5}"
+    p: "+1"
+  - val: "+2{R:.5}{R:.75}"
+    p: "+2"
 R:
-  - val: "[0]"
-  - val: "[1{R}]"
-  - val: "[2{R}{R}]"
+  - p: "[0]"
+  - val: "{R:1.1}{R/]}"
+    p: "[1"
+  - val: "{R:1.2}{R:1.2}{R/]}"
+    p: "[2"
+R/]:
+  p: "]"
+
+P1:
+  - val: "{P1:1 0}{R/]}"
+    p: '[0'
+    freq: d0
+  - val: "{P1/+}{P1:1 0}{R/]}{endl}"
+P1/+:
+  p: "+1"
+endl:
+  p: "\n"
+
+# Demonstrates that in HTML mode the output is escaped
+html:
+  - val: "</td>"
+


### PR DESCRIPTION
FSM `default:` rules now allow `"{}"` to be used to substitute in the (un)matched character
FSM code cleaned up
`recursive.yml` cleaned up slightly, some new nodes to simulate paths, demonstration of FSM to double each character

Switching-nodes may now contain mappings directly, in which case they are constants and are not expanded and not counted by the depth/expansion counters. This feature is experimental.